### PR TITLE
I found an issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 UNAME := $(shell uname)
 CCFLAGS = -I${JAVA_HOME}/include -c -fPIC -fpermissive -g -O0 #-std=c++11 -g -O0
 ifeq ($(UNAME), Linux)
+	CCFLAGS += -I${JAVA_HOME}/include
 	CCFLAGS += -I${JAVA_HOME}/include/linux
 	LINKFLAGS = -z defs -static-libgcc -shared -lc
 endif


### PR DESCRIPTION
In my OS, Ubuntu 20.04 on Windows 10's WSL, I don't have all the .h headers on the folder include/linux.
I was reading on the web and I think we must add this.
Rebase required, obvsly